### PR TITLE
[LOG-50] feat: TextField 로직 수정

### DIFF
--- a/packages/scaffold/src/components/common/flex/Flex.tsx
+++ b/packages/scaffold/src/components/common/flex/Flex.tsx
@@ -1,75 +1,51 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
-import React from "react";
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React from 'react';
 
 interface FlexProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
-  justifyContent?: React.CSSProperties["justifyContent"];
-  alignItems?: React.CSSProperties["alignItems"];
-  gap?: React.CSSProperties["gap"];
-  padding?: React.CSSProperties["padding"];
-  margin?: React.CSSProperties["margin"];
-  borderRadius?: React.CSSProperties["borderRadius"];
+  justifyContent?: React.CSSProperties['justifyContent'];
+  alignItems?: React.CSSProperties['alignItems'];
+  gap?: React.CSSProperties['gap'];
+  padding?: React.CSSProperties['padding'];
+  margin?: React.CSSProperties['margin'];
+  borderRadius?: React.CSSProperties['borderRadius'];
   children: React.ReactNode;
 }
 
-export const Row = (props: FlexProps) => {
-  const {
-    justifyContent: justify,
-    alignItems: align,
-    borderRadius: radius,
-    children,
-    ...others
-  } = props;
+export const Row = React.forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
+  const { justifyContent: justify, alignItems: align, borderRadius: radius, children, ...others } = props;
 
   return (
-    <Flex
-      {...others}
-      justify={justify}
-      align={align}
-      radius={radius}
-      direction={"row"}
-    >
+    <Flex ref={ref} {...others} justify={justify} align={align} radius={radius} direction="row">
       {children}
     </Flex>
   );
-};
+});
 
-export const Col = (props: FlexProps) => {
-  const {
-    justifyContent: justify,
-    alignItems: align,
-    borderRadius: radius,
-    children,
-    ...others
-  } = props;
+export const Col = React.forwardRef<HTMLDivElement, FlexProps>((props, ref) => {
+  const { justifyContent: justify, alignItems: align, borderRadius: radius, children, ...others } = props;
 
   return (
-    <Flex
-      {...others}
-      justify={justify}
-      align={align}
-      radius={radius}
-      direction={"column"}
-    >
+    <Flex ref={ref} {...others} justify={justify} align={align} radius={radius} direction="column">
       {children}
     </Flex>
   );
-};
+});
 
 interface StyledFlexProps {
-  direction: React.CSSProperties["flexDirection"];
-  justify?: React.CSSProperties["justifyContent"];
-  align?: React.CSSProperties["alignItems"];
-  radius?: React.CSSProperties["borderRadius"];
-  padding?: React.CSSProperties["padding"];
-  margin?: React.CSSProperties["margin"];
-  gap?: React.CSSProperties["gap"];
+  direction: React.CSSProperties['flexDirection'];
+  justify?: React.CSSProperties['justifyContent'];
+  align?: React.CSSProperties['alignItems'];
+  radius?: React.CSSProperties['borderRadius'];
+  padding?: React.CSSProperties['padding'];
+  margin?: React.CSSProperties['margin'];
+  gap?: React.CSSProperties['gap'];
 }
 
 const Flex = styled.div<StyledFlexProps>`
   display: flex;
-  flex-direction: ${(props) => props.direction};
+  flex-direction: ${props => props.direction};
   ${({ align }) =>
     align &&
     css`
@@ -96,9 +72,12 @@ const Flex = styled.div<StyledFlexProps>`
     css`
       margin: ${margin};
     `}
-    ${({ radius }) =>
+  ${({ radius }) =>
     radius &&
     css`
       border-radius: ${radius};
     `}
 `;
+
+Row.displayName = 'Row';
+Col.displayName = 'Col';

--- a/packages/scaffold/src/components/common/textField/TextField.tsx
+++ b/packages/scaffold/src/components/common/textField/TextField.tsx
@@ -1,20 +1,23 @@
 import styled from '@emotion/styled';
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import { useCombinedRefs } from '@/hooks/useCombiedRefs';
 
 export type TextFieldAttributes = React.InputHTMLAttributes<HTMLInputElement> & {
   fullSize?: boolean;
 };
 
 const TextField = forwardRef<HTMLInputElement, TextFieldAttributes>(
-  ({ placeholder, onFocusCapture, fullSize = false, value, ...props }, ref) => {
+  ({ placeholder, onFocusCapture, fullSize = false, value, ...props }, forwardedRef) => {
     const [textValue, setTextValue] = useState(value ?? props.defaultValue);
+    const [isFocusHandled, setIsFocusHandled] = useState(false);
+
     const inputRef = useRef<HTMLInputElement>(null);
     const hiddenInputRef = useRef<HTMLInputElement>(null);
-    const [isFocusHandled, setIsFocusHandled] = useState(false);
+
     const initialParentWidth = useRef<number | null>(null);
     const initialWidth = useRef<number | null>(null);
 
-    const combinedRef = useCombinedRefs(ref, inputRef);
+    const combinedRef = useCombinedRefs(forwardedRef, inputRef);
 
     useEffect(() => {
       setTextValue(value);
@@ -145,18 +148,3 @@ const StyledInput = styled.input<StyledInputProps>`
 `;
 
 export default TextField;
-
-function useCombinedRefs<T>(...refs: Array<React.Ref<T>>): React.Ref<T> {
-  return React.useCallback(
-    (element: T) => {
-      refs.forEach(ref => {
-        if (typeof ref === 'function') {
-          ref(element);
-        } else if (ref != null) {
-          (ref as React.MutableRefObject<T>).current = element;
-        }
-      });
-    },
-    [refs]
-  );
-}

--- a/packages/scaffold/src/components/common/textField/TextField.tsx
+++ b/packages/scaffold/src/components/common/textField/TextField.tsx
@@ -20,34 +20,40 @@ const TextField = forwardRef<HTMLInputElement, TextFieldAttributes>(
       setTextValue(value);
     }, [value]);
 
-    useEffect(() => {
-      if (!fullSize && inputRef.current && placeholder && inputRef.current.parentElement) {
-        if (initialParentWidth.current === null) {
-          initialParentWidth.current = inputRef.current.parentElement.offsetWidth;
+    useEffect(
+      function initializeInputWidth() {
+        if (!fullSize && inputRef.current && placeholder && inputRef.current.parentElement) {
+          if (initialParentWidth.current === null) {
+            initialParentWidth.current = inputRef.current.parentElement.offsetWidth;
+          }
+
+          const parentWidth = initialParentWidth.current;
+          const displayValue = placeholder;
+          const textWidth = getTextWidth(displayValue, window.getComputedStyle(inputRef.current).font);
+          const adjustedWidth = Math.min(textWidth + 40, parentWidth - 20);
+
+          inputRef.current.style.width = `${adjustedWidth}px`;
+          initialWidth.current = adjustedWidth;
         }
+      },
+      [placeholder, fullSize]
+    );
 
-        const parentWidth = initialParentWidth.current;
-        const displayValue = placeholder;
-        const textWidth = getTextWidth(displayValue, window.getComputedStyle(inputRef.current).font);
-        const adjustedWidth = Math.min(textWidth + 40, parentWidth - 20);
+    useEffect(
+      function adjustWidthOnTextChange() {
+        if (initialWidth.current && inputRef.current) {
+          const displayValue = textValue !== '' && textValue != null ? textValue.toString() : (placeholder ?? '');
+          const textWidth = getTextWidth(displayValue, window.getComputedStyle(inputRef.current).font);
 
-        inputRef.current.style.width = `${adjustedWidth}px`;
-        initialWidth.current = adjustedWidth;
-      }
-    }, [placeholder, fullSize]);
-
-    useEffect(() => {
-      if (initialWidth.current && inputRef.current) {
-        const displayValue = textValue !== '' && textValue != null ? textValue.toString() : (placeholder ?? '');
-        const textWidth = getTextWidth(displayValue, window.getComputedStyle(inputRef.current).font);
-
-        if (textWidth + 40 > initialWidth.current) {
-          inputRef.current.style.width = `${textWidth + 40}px`;
-        } else {
-          inputRef.current.style.width = `${initialWidth.current}px`;
+          if (textWidth + 40 > initialWidth.current) {
+            inputRef.current.style.width = `${textWidth + 40}px`;
+          } else {
+            inputRef.current.style.width = `${initialWidth.current}px`;
+          }
         }
-      }
-    }, [placeholder, textValue]);
+      },
+      [placeholder, textValue]
+    );
 
     const handleFocusCapture = (event: React.FocusEvent<HTMLInputElement>) => {
       if (isFocusHandled || !hiddenInputRef.current || !inputRef.current) {

--- a/packages/scaffold/src/components/common/textField/TextField.tsx
+++ b/packages/scaffold/src/components/common/textField/TextField.tsx
@@ -12,6 +12,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldAttributes>(
     const hiddenInputRef = useRef<HTMLInputElement>(null);
     const [isFocusHandled, setIsFocusHandled] = useState(false);
     const initialParentWidth = useRef<number | null>(null);
+    const initialWidth = useRef<number | null>(null);
 
     const combinedRef = useCombinedRefs(ref, inputRef);
 
@@ -26,12 +27,27 @@ const TextField = forwardRef<HTMLInputElement, TextFieldAttributes>(
         }
 
         const parentWidth = initialParentWidth.current;
-        const displayValue = textValue !== '' && textValue != null ? textValue.toString() : placeholder;
+        const displayValue = placeholder;
         const textWidth = getTextWidth(displayValue, window.getComputedStyle(inputRef.current).font);
         const adjustedWidth = Math.min(textWidth + 40, parentWidth - 20);
+
         inputRef.current.style.width = `${adjustedWidth}px`;
+        initialWidth.current = adjustedWidth;
       }
-    }, [placeholder, textValue, fullSize]);
+    }, [placeholder, fullSize]);
+
+    useEffect(() => {
+      if (initialWidth.current && inputRef.current) {
+        const displayValue = textValue !== '' && textValue != null ? textValue.toString() : (placeholder ?? '');
+        const textWidth = getTextWidth(displayValue, window.getComputedStyle(inputRef.current).font);
+
+        if (textWidth + 40 > initialWidth.current) {
+          inputRef.current.style.width = `${textWidth + 40}px`;
+        } else {
+          inputRef.current.style.width = `${initialWidth.current}px`;
+        }
+      }
+    }, [placeholder, textValue]);
 
     const handleFocusCapture = (event: React.FocusEvent<HTMLInputElement>) => {
       if (isFocusHandled || !hiddenInputRef.current || !inputRef.current) {

--- a/packages/scaffold/src/components/landing/TextFieldContainer.tsx
+++ b/packages/scaffold/src/components/landing/TextFieldContainer.tsx
@@ -35,13 +35,6 @@ export const TextFieldContainer = ({
 
       const calculatedMaxWidth = containerWidth - emojiWidth - rightContentWidth - 20;
       setMaxWidth(calculatedMaxWidth);
-      console.log(
-        '🚀 ~ useEffect ~ containerWidth:',
-        containerWidth,
-        emojiWidth,
-        rightContentWidth,
-        calculatedMaxWidth
-      );
     }
   }, []);
 

--- a/packages/scaffold/src/components/landing/TextFieldContainer.tsx
+++ b/packages/scaffold/src/components/landing/TextFieldContainer.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useEffect, useRef, useState } from 'react';
 import { RegisterOptions } from 'react-hook-form';
 import { Row } from '../common/flex/Flex';
 import Txt from '../common/text/Txt';
@@ -21,9 +22,33 @@ export const TextFieldContainer = ({
 }: TextFieldContainerProps) => {
   const { register } = useLandingFormContext();
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const emojiRef = useRef<HTMLDivElement>(null);
+  const rightContentRef = useRef<HTMLDivElement>(null);
+  const [maxWidth, setMaxWidth] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (containerRef.current && emojiRef.current && rightContentRef.current) {
+      const containerWidth = containerRef.current.offsetWidth;
+      const emojiWidth = emojiRef.current.offsetWidth;
+      const rightContentWidth = rightContentRef.current.offsetWidth;
+
+      const calculatedMaxWidth = containerWidth - emojiWidth - rightContentWidth - 20;
+      setMaxWidth(calculatedMaxWidth);
+      console.log(
+        '🚀 ~ useEffect ~ containerWidth:',
+        containerWidth,
+        emojiWidth,
+        rightContentWidth,
+        calculatedMaxWidth
+      );
+    }
+  }, []);
+
   return (
-    <Row gap={12} alignItems="center">
+    <Row gap={12} alignItems="center" ref={containerRef}>
       <div
+        ref={emojiRef}
         css={css`
           display: flex;
           justify-content: center;
@@ -42,13 +67,27 @@ export const TextFieldContainer = ({
         gap={8}
         css={css`
           width: fit-content;
+          align-items: center;
         `}
-        alignItems="center"
       >
-        <TextField {...textFieldAttributes} {...register(name, rules)} />
-        <Txt font="Pretendard" size="1.6rem" height={24} weight="500" color="#28292C">
-          {rightContent}
-        </Txt>
+        <TextField
+          css={css`
+            max-width: ${maxWidth ? `${maxWidth}px` : '100%'};
+            white-space: nowrap;
+          `}
+          {...textFieldAttributes}
+          {...register(name, rules)}
+        />
+        <div
+          ref={rightContentRef}
+          css={css`
+            white-space: nowrap;
+          `}
+        >
+          <Txt font="Pretendard" size="1.6rem" height={24} weight="500" color="#28292C">
+            {rightContent}
+          </Txt>
+        </div>
       </Row>
     </Row>
   );

--- a/packages/scaffold/src/hooks/useCombiedRefs.ts
+++ b/packages/scaffold/src/hooks/useCombiedRefs.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+
+export function useCombinedRefs<T>(...refs: Array<React.Ref<T>>): React.Ref<T> {
+  return useCallback(
+    (element: T) => {
+      refs.forEach(ref => {
+        if (typeof ref === 'function') {
+          ref(element);
+        } else if (ref != null) {
+          (ref as React.MutableRefObject<T>).current = element;
+        }
+      });
+    },
+    [refs]
+  );
+}

--- a/packages/scaffold/src/utils/getTextWidth.ts
+++ b/packages/scaffold/src/utils/getTextWidth.ts
@@ -1,0 +1,11 @@
+export function getTextWidth({ text, options }: { text: string; options?: { font?: string } }) {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  if (context != null) {
+    if (options?.font != null) {
+      context.font = options.font;
+    }
+    return context.measureText(text).width;
+  }
+  return 0;
+}


### PR DESCRIPTION
- TextField가 초기의 placeholder 너비를 유지하다가 입력값이 늘어나면 그에 따라 너비가 늘어나도록 수정합니다
- form 페이지에 사용되는 TextFieldContainer가 동적으로 max-width를 연산하여 너비를 제한하도록 합니다
- Flex(Row, Col) 컴포넌트를 외부에서 ref가 주입가능하도록 forwardRef로 감쌌습니다

<img width="373" alt="image" src="https://github.com/user-attachments/assets/0d2ed41b-822e-4f07-9d8e-fa4464e263b1">

